### PR TITLE
chore: make formatting consistent, with prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 80,
+  "tabWidth": 4,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "proseWrap": "always",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -5,37 +5,60 @@
 [![NPM](https://nodei.co/npm/su-sdk.png?downloads=true&downloadRank=true)](https://nodei.co/npm/su-sdk/)
 
 ## Overview
-The SearchUnify SDK enables developers to easily work with the SearchUnify platform and build scalable solutions with search, analytics, crawlers and more. You can get started in minutes using NPM.
-The SearchUnify SDK simplifies use of SearchUnify Services by providing a set of libraries that are consistent and familiar for the developers. It provides support for API lifecycle consideration such as credential management, retries, data marshaling, and serialization. The SearchUnify SDKs also support higher level abstractions for simplified development.
+
+The SearchUnify SDK enables developers to easily work with the SearchUnify
+platform and build scalable solutions with search, analytics, crawlers and more.
+You can get started in minutes using NPM. The SearchUnify SDK simplifies use of
+SearchUnify Services by providing a set of libraries that are consistent and
+familiar for the developers. It provides support for API lifecycle consideration
+such as credential management, retries, data marshaling, and serialization. The
+SearchUnify SDKs also support higher level abstractions for simplified
+development.
 
 ## Key Features
-* HTTP/2 Support and pluggable HTTP layer, new programming interfaces seamlessly take advantage of HTTP/2 features and provide new ways to build applications.
-* Nonblocking I/O, the SearchUnify SDK for Javascript utilizes a new, nonblocking SDK architecture to support true nonblocking I/O. It features truly non blocking asynchronous clients that implement high concurrency across a few threads.
+
+-   HTTP/2 Support and pluggable HTTP layer, new programming interfaces
+    seamlessly take advantage of HTTP/2 features and provide new ways to build
+    applications.
+-   Nonblocking I/O, the SearchUnify SDK for Javascript utilizes a new,
+    nonblocking SDK architecture to support true nonblocking I/O. It features
+    truly non blocking asynchronous clients that implement high concurrency
+    across a few threads.
 
 ## Getting Started
-Sign up for SearchUnify, before you begin, you need a SearchUnify account. Please see the oAuth section of the developer guide for information about how to retrieve your SearchUnify credentials.
+
+Sign up for SearchUnify, before you begin, you need a SearchUnify account.
+Please see the oAuth section of the developer guide for information about how to
+retrieve your SearchUnify credentials.
 
 ## Installation
-SDK requires [Node.js](https://nodejs.org/) to run.
-Install the dependencies and devDependencies and start the server.
+
+SDK requires [Node.js](https://nodejs.org/) to run. Install the dependencies and
+devDependencies and start the server.
 
 ## Execution
-Initiate SearchUnify javascript SDK on Server. Using the SDK, you can route search requests. To start using, initialize the SDK with your URL and API key.
-```javascript
+
+Initiate SearchUnify javascript SDK on Server. Using the SDK, you can route
+search requests. To start using, initialize the SDK with your URL and API key.
+
+```js
 const { SearchUnifyApiClient } = require('su-sdk');
-const apiKey = "key";
+const apiKey = 'key';
 const instanceUrl = 'https://api.searchunify.com';
 const searchunify = new SearchUnifyApiClient(instanceUrl, apiKey);
-server.post("/api/searchunify/search", async (req, res, next) => {
+server.post('/api/searchunify/search', async (req, res, next) => {
     try {
         let response = await searchunify.search(req.body);
         return res.json(response);
     } catch (error) {
         console.log('Exception ${error.message}');
-        return res.status(422).json ({status: false, message: "error message" });
+        return res
+            .status(422)
+            .json({ status: false, message: 'error message' });
     }
-})'
+});
 ```
+
 ## License
 
 MIT

--- a/components/search/search.js
+++ b/components/search/search.js
@@ -1,4 +1,4 @@
-const { HttpRequest } = require("../../utils/requestClient");
+const { HttpRequest } = require('../../utils/requestClient');
 const Apis = require('../../utils/apis.json');
 const { contextObject } = require('../../utils/authType');
 const { HeaderFactory } = require('../../utils/headerFactory');
@@ -6,15 +6,17 @@ const { HeaderFactory } = require('../../utils/headerFactory');
 const searchResultWebsiteClient = async (params) => {
     let authFactory = HeaderFactory(params);
     let config = {
-        method: "post",
-        url: contextObject.provisionKey.instanceUrl + Apis.search.searchResultByPost,
+        method: 'post',
+        url:
+            contextObject.provisionKey.instanceUrl +
+            Apis.search.searchResultByPost,
         data: JSON.stringify(authFactory.body),
-        headers: authFactory.headers
-    }
+        headers: authFactory.headers,
+    };
     let response = await HttpRequest(config);
     return response.data;
-}
+};
 
 module.exports = {
-    searchResultWebsiteClient
-}
+    searchResultWebsiteClient,
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { searchResultWebsiteClient } = require('./components/search/search');
-const { WebsiteSearchValidation } = require("./validators/search.validations");
-const { ProvisionKeyValidation } = require("./validators/auth.validations");
-const { contextObject } = require("./utils/authType");
+const { WebsiteSearchValidation } = require('./validators/search.validations');
+const { ProvisionKeyValidation } = require('./validators/auth.validations');
+const { contextObject } = require('./utils/authType');
 
 /**
  * @author Mohan Rana
@@ -16,8 +16,8 @@ exports.SearchUnifyApiClient = function (instanceUrl, apiKey) {
         let params = {
             enable: true,
             instanceUrl: instanceUrl,
-            accessToken: apiKey
-        }
+            accessToken: apiKey,
+        };
         const isValid = ProvisionKeyValidation(params);
         if (isValid.error) {
             throw new Error(isValid.error.message);
@@ -25,27 +25,26 @@ exports.SearchUnifyApiClient = function (instanceUrl, apiKey) {
         // add required context for other methods.
         contextObject.provisionKey = isValid.value;
         return {
-            search
-        }
+            search,
+        };
     } catch (error) {
         throw new Error(error);
     }
-}
+};
 
 /**
  * @author Mohan Rana
- * @param {Object} params 
+ * @param {Object} params
  * @summary This method is used to get result from searchunify instance.
  */
 
 const search = async (params) => {
     try {
         const isValid = await WebsiteSearchValidation(params);
-        if (isValid.error)
-            throw new Error(isValid.error.message);
+        if (isValid.error) throw new Error(isValid.error.message);
         let response = await searchResultWebsiteClient(isValid.value);
         return response;
     } catch (error) {
         throw new Error(error);
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SearchUnify javascript software development kit.",
   "main": "index.js",
   "scripts": {
+    "prettier": "npx prettier@2.x -w '**/*.{js,md}'",
     "start": "node index.js"
   },
   "repository": {

--- a/utils/authType.js
+++ b/utils/authType.js
@@ -1,14 +1,13 @@
-
 exports.contextObject = {
     apiKey: {
         enable: false,
         instanceUrl: '',
-        apiKey: ''
+        apiKey: '',
     },
     provisionKey: {
         enable: false,
         instanceUrl: '',
-        accessToken: ''
+        accessToken: '',
     },
     oauth: {
         enable: false,
@@ -16,6 +15,6 @@ exports.contextObject = {
         clientId: '',
         secret: '',
         username: '',
-        password: ''
-    }
-}
+        password: '',
+    },
+};

--- a/utils/headerFactory.js
+++ b/utils/headerFactory.js
@@ -3,11 +3,11 @@ const { contextObject } = require('./authType');
 exports.HeaderFactory = (params) => {
     let options = {
         body: {},
-        headers: { 'Content-Type': 'application/json' }
-    }
+        headers: { 'Content-Type': 'application/json' },
+    };
     if (contextObject.provisionKey.enable) {
         params['accessToken'] = contextObject.provisionKey.accessToken;
         options.body = params;
     }
     return options;
-}
+};

--- a/utils/requestClient.js
+++ b/utils/requestClient.js
@@ -7,4 +7,4 @@ exports.HttpRequest = async (options) => {
     } catch (error) {
         throw new Error(error);
     }
-}
+};

--- a/validators/auth.validations.js
+++ b/validators/auth.validations.js
@@ -4,10 +4,10 @@ exports.ProvisionKeyValidation = (options) => {
     const schema = Joi.object().keys({
         enable: Joi.boolean().invalid(false).label(`enable must be true`),
         accessToken: Joi.string().required(),
-        instanceUrl: Joi.string().required()
+        instanceUrl: Joi.string().required(),
     });
     // Removing trailing slash.
-    options.instanceUrl = options.instanceUrl.replace(/\/$/, "");
+    options.instanceUrl = options.instanceUrl.replace(/\/$/, '');
     const result = schema.validate(options);
     return result;
-}
+};

--- a/validators/search.validations.js
+++ b/validators/search.validations.js
@@ -1,9 +1,11 @@
 const Joi = require('joi');
 
 exports.WebsiteSearchValidation = (options) => {
-    const schema = Joi.object().keys({
-        uid: Joi.string().required()
-    }).unknown(true);
+    const schema = Joi.object()
+        .keys({
+            uid: Joi.string().required(),
+        })
+        .unknown(true);
     const result = schema.validate(options);
     return result;
-}
+};


### PR DESCRIPTION
used prettier to make symbols and whitespace consistent with the official CommonMark (Markdown) format and Prettier.

- consistently use single quotes rather than mix and match
- consistent line lengths for readability