### PR TITLE
docs: bugfix example and make idiomatic to express

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 80,
+  "tabWidth": 4,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "proseWrap": "always",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -42,20 +42,24 @@ Initiate SearchUnify javascript SDK on Server. Using the SDK, you can route
 search requests. To start using, initialize the SDK with your URL and API key.
 
 ```js
+'use strict';
+
 const { SearchUnifyApiClient } = require('su-sdk');
 const apiKey = 'key';
 const instanceUrl = 'https://api.searchunify.com';
 const searchunify = new SearchUnifyApiClient(instanceUrl, apiKey);
-server.post('/api/searchunify/search', async (req, res, next) => {
-    try {
+
+app.post('/api/searchunify/search', function (req, res, next) {
+    Promise.then(async function () {
         let response = await searchunify.search(req.body);
-        return res.json(response);
-    } catch (error) {
-        console.log('Exception ${error.message}');
-        return res
-            .status(422)
-            .json({ status: false, message: 'error message' });
-    }
+        res.json(response);
+    }).catch(next);
+});
+
+app.use('/', function (err, req, res, next) {
+    console.error(`Exception ${err.message}`);
+    res.status(422);
+    res.json({ status: false, message: 'error message' });
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,37 +5,60 @@
 [![NPM](https://nodei.co/npm/su-sdk.png?downloads=true&downloadRank=true)](https://nodei.co/npm/su-sdk/)
 
 ## Overview
-The SearchUnify SDK enables developers to easily work with the SearchUnify platform and build scalable solutions with search, analytics, crawlers and more. You can get started in minutes using NPM.
-The SearchUnify SDK simplifies use of SearchUnify Services by providing a set of libraries that are consistent and familiar for the developers. It provides support for API lifecycle consideration such as credential management, retries, data marshaling, and serialization. The SearchUnify SDKs also support higher level abstractions for simplified development.
+
+The SearchUnify SDK enables developers to easily work with the SearchUnify
+platform and build scalable solutions with search, analytics, crawlers and more.
+You can get started in minutes using NPM. The SearchUnify SDK simplifies use of
+SearchUnify Services by providing a set of libraries that are consistent and
+familiar for the developers. It provides support for API lifecycle consideration
+such as credential management, retries, data marshaling, and serialization. The
+SearchUnify SDKs also support higher level abstractions for simplified
+development.
 
 ## Key Features
-* HTTP/2 Support and pluggable HTTP layer, new programming interfaces seamlessly take advantage of HTTP/2 features and provide new ways to build applications.
-* Nonblocking I/O, the SearchUnify SDK for Javascript utilizes a new, nonblocking SDK architecture to support true nonblocking I/O. It features truly non blocking asynchronous clients that implement high concurrency across a few threads.
+
+-   HTTP/2 Support and pluggable HTTP layer, new programming interfaces
+    seamlessly take advantage of HTTP/2 features and provide new ways to build
+    applications.
+-   Nonblocking I/O, the SearchUnify SDK for Javascript utilizes a new,
+    nonblocking SDK architecture to support true nonblocking I/O. It features
+    truly non blocking asynchronous clients that implement high concurrency
+    across a few threads.
 
 ## Getting Started
-Sign up for SearchUnify, before you begin, you need a SearchUnify account. Please see the oAuth section of the developer guide for information about how to retrieve your SearchUnify credentials.
+
+Sign up for SearchUnify, before you begin, you need a SearchUnify account.
+Please see the oAuth section of the developer guide for information about how to
+retrieve your SearchUnify credentials.
 
 ## Installation
-SDK requires [Node.js](https://nodejs.org/) to run.
-Install the dependencies and devDependencies and start the server.
+
+SDK requires [Node.js](https://nodejs.org/) to run. Install the dependencies and
+devDependencies and start the server.
 
 ## Execution
-Initiate SearchUnify javascript SDK on Server. Using the SDK, you can route search requests. To start using, initialize the SDK with your URL and API key.
-```javascript
+
+Initiate SearchUnify javascript SDK on Server. Using the SDK, you can route
+search requests. To start using, initialize the SDK with your URL and API key.
+
+```js
 const { SearchUnifyApiClient } = require('su-sdk');
-const apiKey = "key";
+const apiKey = 'key';
 const instanceUrl = 'https://api.searchunify.com';
 const searchunify = new SearchUnifyApiClient(instanceUrl, apiKey);
-server.post("/api/searchunify/search", async (req, res, next) => {
+server.post('/api/searchunify/search', async (req, res, next) => {
     try {
         let response = await searchunify.search(req.body);
         return res.json(response);
     } catch (error) {
         console.log('Exception ${error.message}');
-        return res.status(422).json ({status: false, message: "error message" });
+        return res
+            .status(422)
+            .json({ status: false, message: 'error message' });
     }
-})'
+});
 ```
+
 ## License
 
 MIT


### PR DESCRIPTION
I'm assuming that this example is intended to be geared towards people who use express, so I made it more express-like.

- fix use of single quotes where template string was intended
- add "use strict" because this is node code, not transpiled
- use `app` (the normal name of an express router) rather than `server`
- no redundant `return` which may be confusing to the reader (there's nothing being returned)
- consistent use of single quotes (rather than mixing single and double quotes)
- go full-on async/await (using .catch() rather than try{})
- use express' built-in `next(err)` handler rather than a one-off error handler
- add some whitespace for readability

# Preview

See the concise diff at https://github.com/searchunify/su-sdk/pull/2/commits/46a5302413629bdb16997ebd9977f1a6328bf988 (this is built in part on the prettier PR, but just the README part)

Preview at https://github.com/coolaj86/su-sdk/tree/express#execution